### PR TITLE
Added fixes for release 109

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>aem-learning-core</artifactId>

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.adobe.learning</groupId>
     <artifactId>aem-learning</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <description>Learning Site</description>
 
     <modules>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.apps/src/main/content/jcr_root/apps/learning/components/mylearning/clientlibs/js/cprimewidget.js
+++ b/ui.apps/src/main/content/jcr_root/apps/learning/components/mylearning/clientlibs/js/cprimewidget.js
@@ -26,7 +26,7 @@ governing permissions and limitations under the License.
     .set("catalogOverviewPageLink", ["catalogOverview", "catalog", new RegExp(/selectedListableCatalogIds=(\d+)/i)])
     .set("courseInstancePreviewPageLink", ["loInstancePreview", "course", new RegExp(/course\/(\d+)\/instance\/(\d+)\/preview\??(.*)/i)])
     .set("courseInstancePreviewPageShowLink", ["loInstancePreview", "course", new RegExp(/course\/(\d+)\/instance\/(\d+)\/preview\??(.*)/i)])
-    .set("catalogPageLink", ["catalogPage"])
+    .set("catalogPageLink", ["catalogPage","catalog", new RegExp(/catalogs=(\d+)/i)])
     .set("myLearningPageLink", ["myLearningPage"])
     .set("postsLink", ["postsPage", new RegExp(/board\/(\d+)/i)])
     .set("allboardsPageLink", ["boardsPage"])
@@ -120,9 +120,15 @@ governing permissions and limitations under the License.
           window.ALM.navigateToCatalogPage(catalogIds);
           break;
 
-        case "catalogPage":
-          window.ALM.navigateToExplorePage();
+        case "catalogPage":{
+          const catalogIds = e.route.match(almLinksMapObj[2])[1];
+          if(catalogIds){
+            window.ALM.navigateToCatalogPage(catalogIds);
+          }else{
+            window.ALM.navigateToExplorePage();
+          }
           break;
+        }
 
         case "myLearningPage":
           window.ALM.navigateToCatalogPageForStates("enrolled");

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend/pom.xml
+++ b/ui.frontend/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.adobe.learning</groupId>
         <artifactId>aem-learning</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui.frontend/src/almLib/common/ALMCustomHooks.tsx
+++ b/ui.frontend/src/almLib/common/ALMCustomHooks.tsx
@@ -225,6 +225,7 @@ class ALMCustomHooks implements ICustomHooks {
       value: item.name,
       label: item.name,
       checked: false,
+      id: item.id,
     }));
     catalogList = updateFilterList(catalogList, queryParams, "catalogs");
     const defaultFiltersState = getDefaultFiltersState();

--- a/ui.frontend/src/almLib/utils/catalog.ts
+++ b/ui.frontend/src/almLib/utils/catalog.ts
@@ -72,7 +72,7 @@ export const getOrUpdateCatalogFilters = async (): Promise<
     }
     const config = getALMConfig();
     const catalogPromise = await RestAdapter.get({
-      url: `${config.primeApiURL}catalogs`,
+      url: `${config.primeApiURL}catalogs?page[limit]=100`
     });
     setItemToStorage(PRIME_CATALOG_FILTER, catalogPromise);
     return JsonApiParse(catalogPromise)?.catalogList;
@@ -86,7 +86,7 @@ const getCatalogParamsForAPi = async (
   const catalogFilterFromState = catalogState.split(",");
   let returnValue = "";
   catalogFilterFromStorage?.forEach((item) => {
-    if (catalogFilterFromState.indexOf(item.name) > -1) {
+    if (catalogFilterFromState.indexOf(item.name) > -1 || catalogFilterFromState.indexOf(item.id) > -1) {
       returnValue += returnValue ? "," + item.id : item.id;
     }
   });

--- a/ui.frontend/src/almLib/utils/filters.ts
+++ b/ui.frontend/src/almLib/utils/filters.ts
@@ -247,7 +247,7 @@ export const updateFilterList = (
     : [];
 
   list?.forEach((item: any) => {
-    if (filtersFromUrlTypeSplitArray?.includes(item.value)) {
+    if (filtersFromUrlTypeSplitArray?.includes(item.value) || filtersFromUrlTypeSplitArray?.includes(item.id)) {
       item.checked = true;
     }
   });


### PR DESCRIPTION
Below issues have been fixed in this PR:

1. My Learning Widget (Catalog Browser) is not redirecting to the Catalog page correctly.
2. The go to catalog(Empty Card) in strip option should redirect to the particular Catalog page
3. Catalog filter panel shows only 10 catalogs at most in AEM 